### PR TITLE
BLOCK_ADC referenced an undeclared variable

### DIFF
--- a/dmg/dmgfile.c
+++ b/dmg/dmgfile.c
@@ -12,6 +12,7 @@
 
 static void cacheRun(DMG* dmg, BLKXTable* blkx, int run) {
 	size_t bufferSize;
+	size_t bufferRead;
 	z_stream strm;
 	void* inBuffer;
 	int ret;
@@ -30,14 +31,14 @@ static void cacheRun(DMG* dmg, BLKXTable* blkx, int run) {
 	ASSERT(dmg->dmg->seek(dmg->dmg, blkx->dataStart + blkx->runs[run].compOffset) == 0, "fseeko");
 	
     switch(blkx->runs[run].type) {
-                 case BLOCK_ADC:
-			 bufferRead = 0;
-			 do {
-				 strm.avail_in = dmg->dmg->read(dmg->dmg, inBuffer, blkx->runs[run].compLength);
-				 strm.avail_out = adc_decompress(strm.avail_in, inBuffer, bufferSize, dmg->runData, &have);
-				 bufferRead+=strm.avail_out;
-			 } while (bufferRead < blkx->runs[run].compLength);
-			 break;
+		case BLOCK_ADC:
+			bufferRead = 0;
+			do {
+				strm.avail_in = dmg->dmg->read(dmg->dmg, inBuffer, blkx->runs[run].compLength);
+				strm.avail_out = adc_decompress(strm.avail_in, inBuffer, bufferSize, dmg->runData, &have);
+				bufferRead+=strm.avail_out;
+			} while (bufferRead < blkx->runs[run].compLength);
+			break;
 		case BLOCK_ZLIB:
 			strm.zalloc = Z_NULL;
 			strm.zfree = Z_NULL;

--- a/dmg/io.c
+++ b/dmg/io.c
@@ -144,6 +144,7 @@ void extractBLKX(AbstractFile* in, AbstractFile* out, BLKXTable* blkx) {
 	unsigned char* outBuffer;
 	unsigned char zero;
 	size_t bufferSize;
+	size_t bufferRead;
 	size_t have;
 	off_t initialOffset;
 	int i;
@@ -182,14 +183,14 @@ void extractBLKX(AbstractFile* in, AbstractFile* out, BLKXTable* blkx) {
 		printf("run %d: start=%" PRId64 " sectors=%" PRId64 ", length=%" PRId64 ", fileOffset=0x%" PRIx64 "\n", i, initialOffset + (blkx->runs[i].sectorStart * SECTOR_SIZE), blkx->runs[i].sectorCount, blkx->runs[i].compLength, blkx->runs[i].compOffset);
 		
 		switch(blkx->runs[i].type) {
-		        case BLOCK_ADC:
+			case BLOCK_ADC:
 				do {
 					ASSERT((strm.avail_in = in->read(in, inBuffer, blkx->runs[i].compLength)) == blkx->runs[i].compLength, "fread");
 					strm.avail_out = adc_decompress(strm.avail_in, inBuffer, bufferSize, outBuffer, &have);
 					ASSERT(out->write(out, outBuffer, have) == have, "mWrite");
 					bufferRead+=strm.avail_out;
 				} while (bufferRead < blkx->runs[i].compLength);
-		  break;
+				break;
 			case BLOCK_ZLIB:
 				strm.zalloc = Z_NULL;
 				strm.zfree = Z_NULL;


### PR DESCRIPTION
Loop counter was missing in 'case BLOCK_ADC'
added it as 'size_t bufferRead', and cleaned up formatting.