### PR TITLE
dmg: fix checksum error

### DIFF
--- a/dmg/dmglib.c
+++ b/dmg/dmglib.c
@@ -380,6 +380,7 @@ int convertToDMG(AbstractFile* abstractIn, AbstractFile* abstractOut) {
 		abstractIn->seek(abstractIn, 0);
 		blkx = insertBLKX(abstractOut, abstractIn, 0, fileLength/SECTOR_SIZE, ENTIRE_DEVICE_DESCRIPTOR, CHECKSUM_CRC32,
 					&BlockCRC, &uncompressedToken, &CRCProxy, &dataForkToken, NULL);
+		blkx->checksum.data[0] = uncompressedToken.crc;
 		resources = insertData(resources, "blkx", 0, "whole disk (unknown partition : 0)", (const char*) blkx, sizeof(BLKXTable) + (blkx->blocksRunCount * sizeof(BLKXRun)), ATTRIBUTE_HDIUTIL);
 		free(blkx);
 		


### PR DESCRIPTION
I realize that @planetbeing is not really active or responsive here, but I'm submitting this in the event that someone who's googling this issue may stumble onto this PR.

When using 'dmg' to compact an existing dmg, the resulting file has an invalid checksum. A workaround is proposed here: http://shanemcc.co.uk/libdmg/ which disables the checksum. That seems less than ideal.

Instead, this change adds the checksum data where it should be. My Macbook on 10.6 is happy with it, whereas before the change it reported the broken checksum.