### PR TITLE
Initialize checksum structs to avoid inserting unused garbage padding

### DIFF
--- a/dmg/dmglib.c
+++ b/dmg/dmglib.c
@@ -124,6 +124,8 @@ int buildDmg(AbstractFile* abstractIn, AbstractFile* abstractOut) {
 	nsiz = NULL;
     
 	memset(&dataForkToken, 0, sizeof(ChecksumToken));
+	memset(koly.fUDIFMasterChecksum.data, 0, sizeof(koly.fUDIFMasterChecksum.data));
+	memset(koly.fUDIFDataForkChecksum.data, 0, sizeof(koly.fUDIFDataForkChecksum.data));
 	
 	printf("Creating and writing DDM and partition map...\n"); fflush(stdout);
 	
@@ -296,6 +298,8 @@ int convertToDMG(AbstractFile* abstractIn, AbstractFile* abstractOut) {
 	nsiz = NULL;
 	myNSiz = NULL;
 	memset(&dataForkToken, 0, sizeof(ChecksumToken));
+	memset(koly.fUDIFMasterChecksum.data, 0, sizeof(koly.fUDIFMasterChecksum.data));
+	memset(koly.fUDIFDataForkChecksum.data, 0, sizeof(koly.fUDIFDataForkChecksum.data));
 	
 	partitions = (Partition*) malloc(SECTOR_SIZE);
 	


### PR DESCRIPTION
I realize that @planetbeing is not really active or responsive here, but I'm submitting this in the event that someone who's googling this issue may stumble onto this PR.

for the fUDIFDataForkChecksum.data and fUDIFMasterChecksum.data structures, it
appears as though only the first int is ever used for checksumming, but the
other bytes are still written to the image. Initialize them so they don't
contain random garbage.

With this change, using dmg to compress an existing dmg produces consistent output.