### PR TITLE
Make it work for 32 bits platform with _FILE_OFFSET_BITS=64

### DIFF
--- a/hfs/hfslib.c
+++ b/hfs/hfslib.c
@@ -635,7 +635,7 @@ void hfs_ls(Volume* volume, const char* path) {
 		printf("No such file or directory\n");
 	}
 
-	printf("Total filesystem size: %d, free: %d\n", (volume->volumeHeader->totalBlocks - volume->volumeHeader->freeBlocks) * volume->volumeHeader->blockSize, volume->volumeHeader->freeBlocks * volume->volumeHeader->blockSize);
+	printf("Total filesystem size: %lld, free: %lld\n", ((uint64_t)(volume->volumeHeader->totalBlocks - volume->volumeHeader->freeBlocks)) * volume->volumeHeader->blockSize, ((uint64_t)volume->volumeHeader->freeBlocks) * volume->volumeHeader->blockSize); // cast to uint64_t to be plateform independant.
 	
 	free(record);
 }

--- a/hfs/rawfile.c
+++ b/hfs/rawfile.c
@@ -200,12 +200,12 @@ static int rawFileRead(io_func* io,off_t location, size_t size, void *buffer) {
 		possible = extent->blockCount * blockSize - locationInBlock;
 
 		if(size > possible) {
-			ASSERT(READ(volume->image, extent->startBlock * blockSize + locationInBlock, possible, buffer), "READ");
+			ASSERT(READ(volume->image, ((off_t)extent->startBlock) * blockSize + locationInBlock, possible, buffer), "READ");
 			size -= possible;
 			buffer = (void*)(((size_t)buffer) + possible);
 			extent = extent->next;
 		} else {
-			ASSERT(READ(volume->image, extent->startBlock * blockSize + locationInBlock, size, buffer), "READ");
+			ASSERT(READ(volume->image, ((off_t)extent->startBlock) * blockSize + locationInBlock, size, buffer), "READ");
 			break;
 		}
 


### PR DESCRIPTION
There was a arithmetic problem on 32 bits platform when off_t is 64 bits.
Basically, we have to make sure to convert to 64 bits BEFORE the multiplication. Hence things like : ((off_t)extent->startBlock) * blockSize.